### PR TITLE
Add router and OpenAI summary flow

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,7 +31,8 @@
       "typedRoutes": true
     },
     "extra": {
-      "azureEndpoint": "https://audiotranscriben.azurewebsites.net/api/HttpTrigger2?"
+      "azureEndpoint": "https://audiotranscriben.azurewebsites.net/api/HttpTrigger2?",
+      "openaiKey": "YOUR-OPENAI-KEY"
     }
   }
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function RootLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/app/result.tsx
+++ b/app/result.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useLocalSearchParams } from 'expo-router';
+import { ScrollView, View, Text, StyleSheet, Pressable, Share } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+import { colors, fontFamily, rounded } from '../theme';
+
+export default function Result() {
+  const params = useLocalSearchParams<{ improved?: string; summary?: string }>();
+  const improved = params.improved ?? '';
+  const summary = params.summary ?? '';
+
+  const copy = async (text: string) => {
+    await Clipboard.setStringAsync(text);
+  };
+
+  const share = async (text: string) => {
+    try {
+      await Share.share({ message: text });
+    } catch {}
+  };
+
+  return (
+    <ScrollView style={[styles.container, { backgroundColor: colors.bg }]} contentContainerStyle={{ padding: 20 }}>
+      <Text style={styles.heading}>Verbeterde Transcript</Text>
+      <Text selectable style={styles.transcript}>{improved}</Text>
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>Samenvatting</Text>
+        <Text selectable style={styles.summary}>{summary}</Text>
+        <View style={styles.actions}>
+          <Pressable style={styles.button} onPress={() => copy(summary)}>
+            <Text style={styles.buttonText}>Kopieer</Text>
+          </Pressable>
+          <Pressable style={styles.button} onPress={() => share(summary)}>
+            <Text style={styles.buttonText}>Deel</Text>
+          </Pressable>
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  heading: { fontFamily, fontSize: 24, color: '#000', marginBottom: 16 },
+  transcript: { fontFamily, color: '#000', marginBottom: 24 },
+  card: { backgroundColor: colors.accent, padding: 20, borderRadius: rounded },
+  cardTitle: { fontFamily, fontSize: 18, marginBottom: 8 },
+  summary: { fontFamily, color: '#000', marginBottom: 12 },
+  actions: { flexDirection: 'row', gap: 10 },
+  button: { backgroundColor: colors.primary, paddingHorizontal: 16, paddingVertical: 8, borderRadius: rounded },
+  buttonText: { color: '#fff', fontFamily },
+});

--- a/index.tsx
+++ b/index.tsx
@@ -1,0 +1,1 @@
+export { default } from 'expo-router/entry';

--- a/openai.ts
+++ b/openai.ts
@@ -1,0 +1,28 @@
+import Constants from 'expo-constants';
+import OpenAI from 'openai';
+
+const { openaiKey } = (Constants.expoConfig?.extra ?? {}) as { openaiKey: string };
+
+const openai = new OpenAI({ apiKey: openaiKey });
+
+export async function improveTranscript(text: string) {
+  const r = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [
+      { role: 'system', content: 'Je bent een Nederlandse tekst-editor.' },
+      { role: 'user', content: `Corrigeer interpunctie en grammatica:\n\n${text}` },
+    ],
+  });
+  return r.choices[0].message.content.trim();
+}
+
+export async function summariseTranscript(text: string) {
+  const r = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [
+      { role: 'system', content: 'Vat Nederlandse teksten samen.' },
+      { role: 'user', content: `Vat dit samen (max 120 woorden):\n\n${text}` },
+    ],
+  });
+  return r.choices[0].message.content.trim();
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "expo-web-browser": "~14.2.0",
     "expo-av": "~15.1.7",
     "expo-document-picker": "~15.2.2",
+    "openai": "^4.26.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
@@ -41,6 +42,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
+    "@types/react-router-native": "^5.3.3",
     "typescript": "~5.8.3",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0"


### PR DESCRIPTION
## Summary
- set expo-router as entry point
- move uploader screen to app/index.tsx
- add stack layout
- create result screen for improved transcript and summary
- add OpenAI helper
- update config with `openaiKey`
- add OpenAI deps

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687807879f0c8333adc6a9cebe2e0f60