### PR TITLE
Add result page with transcript and summary; redesign UI

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,7 +3,12 @@ import * as DocumentPicker from 'expo-document-picker';
 import { useRouter } from 'expo-router';
 import React from 'react';
 import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
-import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { Ionicons } from '@expo/vector-icons';
 import { uploadToAzure } from '../azure';
 import { LoadingOverlay } from '../components/LoadingOverlay';
 import { summarizeTranscriptWithGrok } from '../openai';
@@ -64,18 +69,17 @@ export default function App() {
       );
       console.log('Transcript from Azure:', transcript);
 
-      const improved ="";
       const detectedLang = 'nl';
       const summary = await summarizeTranscriptWithGrok(transcript, detectedLang);
       router.push({
         pathname: '/result',
         params: {
-          improved,
+          transcript,
           summary: typeof summary === 'string'
             ? summary
             : JSON.stringify(summary),
         },
-       });
+      });
     } catch (e: any) {
       Alert.alert('Fout', e.message);
     } finally {
@@ -85,8 +89,11 @@ export default function App() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      <Text style={styles.title}>Luisterslim</Text>
+      <Text style={styles.subtitle}>Kies een geluidsbestand om te transcriberen</Text>
       <Pressable style={styles.button} onPress={pickAudio}>
-        <Text style={styles.buttonText}>Pick Audio</Text>
+        <Ionicons name="document-attach-outline" size={20} color="#fff" />
+        <Text style={styles.buttonText}>Kies audio</Text>
       </Pressable>
       {file && (
         <Animated.View style={[styles.card, animatedStyle]}>
@@ -95,11 +102,14 @@ export default function App() {
             {format(file.duration)} • {Math.round(file.size / 1024)} kB
           </Text>
           <Pressable style={styles.transcribeButton} onPress={transcribe}>
-            <Text style={styles.transcribeText}>Notuleren</Text>
+            <Text style={styles.transcribeText}>Transcribe</Text>
           </Pressable>
         </Animated.View>
       )}
-      <LoadingOverlay visible={overlay} onCancel={() => (overlay.value = withTiming(0, { duration: 300 }))} />
+      <LoadingOverlay
+        visible={overlay}
+        onCancel={() => (overlay.value = withTiming(0, { duration: 300 }))}
+      />
     </View>
   );
 }
@@ -108,10 +118,25 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
     padding: 20,
+    paddingTop: 80,
+  },
+  title: {
+    fontFamily,
+    color: colors.text,
+    fontSize: 32,
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontFamily,
+    color: colors.text,
+    marginBottom: 24,
   },
   button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
     backgroundColor: colors.primary,
     paddingHorizontal: 24,
     paddingVertical: 12,
@@ -127,17 +152,18 @@ const styles = StyleSheet.create({
     padding: 20,
     width: '100%',
     borderRadius: rounded,
-    backgroundColor: '#fff',
+    backgroundColor: colors.accent,
     alignItems: 'center',
   },
   name: {
     fontFamily,
     fontSize: 16,
+    color: colors.text,
     marginBottom: 4,
   },
   meta: {
     fontFamily,
-    color: colors.accent,
+    color: colors.text,
     marginBottom: 12,
   },
   transcribeButton: {
@@ -145,6 +171,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingVertical: 10,
     borderRadius: rounded,
+    marginTop: 10,
   },
   transcribeText: {
     color: '#fff',

--- a/app/result.tsx
+++ b/app/result.tsx
@@ -7,8 +7,8 @@ import { colors, fontFamily, rounded } from '../theme'
 
 export default function Result() {
   // pull them straight from the URL:
-  const { improved = '', summary = '' } = useLocalSearchParams<{
-    improved?: string
+  const { transcript = '', summary = '' } = useLocalSearchParams<{
+    transcript?: string
     summary?: string
   }>()
 
@@ -32,8 +32,8 @@ export default function Result() {
       style={[styles.container, { backgroundColor: colors.bg }]}
       contentContainerStyle={{ padding: 20 }}
     >
-      <Text style={styles.heading}>Verbeterde Transcript</Text>
-      <Text selectable style={styles.transcript}>{improved}</Text>
+      <Text style={styles.heading}>Transcript</Text>
+      <Text selectable style={styles.transcript}>{transcript}</Text>
 
       <View style={styles.card}>
         <Text style={styles.cardTitle}>Samenvatting</Text>
@@ -53,12 +53,17 @@ export default function Result() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  heading: { fontFamily, fontSize: 24, color: '#000', marginBottom: 16 },
-  transcript: { fontFamily, color: '#000', marginBottom: 24 },
+  heading: { fontFamily, fontSize: 24, color: colors.text, marginBottom: 16 },
+  transcript: { fontFamily, color: colors.text, marginBottom: 24 },
   card: { backgroundColor: colors.accent, padding: 20, borderRadius: rounded },
-  cardTitle: { fontFamily, fontSize: 18, marginBottom: 8 },
-  summary: { fontFamily, color: '#000', marginBottom: 12 },
+  cardTitle: { fontFamily, fontSize: 18, marginBottom: 8, color: colors.text },
+  summary: { fontFamily, color: colors.text, marginBottom: 12 },
   actions: { flexDirection: 'row', gap: 10 },
-  button: { backgroundColor: colors.primary, paddingHorizontal: 16, paddingVertical: 8, borderRadius: rounded },
+  button: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: rounded,
+  },
   buttonText: { color: '#fff', fontFamily },
 })

--- a/theme.ts
+++ b/theme.ts
@@ -1,9 +1,12 @@
 export const colors = {
-  primary: '#3FB0AC',
-  accent: '#FFC857',
-  bg: '#FFF9F4',
+  primary: '#4361EE', // vibrant blue for buttons and highlights
+  accent: '#EEF2FF',  // subtle card background
+  bg: '#F9FAFB',      // light app background
+  text: '#111827',    // default text color
 };
 
-export const fontFamily = 'Poppins-Medium';
+// System font keeps it simple and consistent across platforms
+export const fontFamily = 'System';
 
-export const rounded = 20;
+// Slightly smaller rounding for a modern look
+export const rounded = 12;


### PR DESCRIPTION
## Summary
- redesign theme colors and rounded corners
- show header and improved button layout on home screen
- push transcript and summary to result page
- display transcript and summary with new styling

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d1ff89a483339f5958155709ebe3