### PR TITLE
Move API secrets to environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-azureEndpoint="https://audiotranscriben.azurewebsites.net/api/HttpTrigger2?",
-openaiKey= "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",
-GROK_API_KEY="xai-gkVEUemDMkC8pCUkaBPhyzV4BoqMLJvEMq41kK7Tx2LNtkBRJZyJYBqd13hFOb0rIYoG4OlQKtyK7sZb",
-GROK_BASE_URL="https://api.x.ai/v1"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+AZURE_ENDPOINT=
+OPENAI_KEY=
+GROK_API_KEY=
+GROK_BASE_URL=https://api.x.ai/v1

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.*
 *.pem
 
 # local env files
+.env
 .env*.local
 
 # typescript

--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    npm install
    ```
 
-2. Start the app
+2. Copy the example environment file and fill in your API keys:
+
+   ```bash
+   cp .env.example .env
+   # edit .env and add your secrets
+   ```
+
+3. Start the app
 
    ```bash
    npx expo start

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,12 @@
+import 'dotenv/config';
+
+export default ({ config }) => ({
+  ...config,
+  extra: {
+    ...config.extra,
+    azureEndpoint: process.env.AZURE_ENDPOINT,
+    openaiKey: process.env.OPENAI_KEY,
+    GROK_API_KEY: process.env.GROK_API_KEY,
+    GROK_BASE_URL: process.env.GROK_BASE_URL,
+  },
+});

--- a/app.json
+++ b/app.json
@@ -30,12 +30,6 @@
     ],
     "experiments": {
       "typedRoutes": true
-    },
-    "extra": {
-      "azureEndpoint": "https://audiotranscriben.azurewebsites.net/api/HttpTrigger2?",
-      "openaiKey": "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",
-      "GROK_API_KEY": "xai-gkVEUemDMkC8pCUkaBPhyzV4BoqMLJvEMq41kK7Tx2LNtkBRJZyJYBqd13hFOb0rIYoG4OlQKtyK7sZb",
-      "GROK_BASE_URL": "https://api.x.ai/v1"
     }
   }
 }

--- a/azure.ts
+++ b/azure.ts
@@ -1,6 +1,8 @@
 // azure.ts
+import Constants from 'expo-constants';
 
-const azureEndpoint = process.env.azureEndpoint || '';
+const azureEndpoint =
+  (Constants.expoConfig?.extra?.azureEndpoint as string) || '';
 
 export async function uploadToAzure(
   uri: string,


### PR DESCRIPTION
## Summary
- keep secret environment variables out of source control
- expose env vars to Expo via `app.config.js`
- adjust Azure helper to read endpoint from Expo config
- update docs for env setup
- add `.env.example` and ignore real `.env`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879241974c48333bae0326cf497d3a3